### PR TITLE
bugfix - AOMRemoval threads where not removed when POA is destroyed

### DIFF
--- a/src/org/jacorb/poa/POA.java
+++ b/src/org/jacorb/poa/POA.java
@@ -195,7 +195,7 @@ public class POA
         {
             for (int i=0; i<policies.length; i++)
             {
-                all_policies.put(ObjectUtil.newInteger( policies[i].policy_type() ),
+                all_policies.put(ObjectUtil.newInteger(policies[i].policy_type()),
                                   policies[i]);
 
                 switch (policies[i].policy_type())
@@ -337,7 +337,7 @@ public class POA
     public Servant _incarnateServant(byte[] oid, ServantActivator sa)
         throws org.omg.PortableServer.ForwardRequest
     {
-        return aom.incarnate(oid, sa, this);
+        return aom.incarnate(new ByteArrayKey(oid), sa, this);
     }
 
     /**
@@ -985,7 +985,7 @@ public class POA
         }
 
         aom.remove(
-            oid,
+            new ByteArrayKey(oid),
             requestController,
             useServantManager() ? (ServantActivator)servantManager : null,
             this,
@@ -1628,6 +1628,12 @@ public class POA
             if (logger.isDebugEnabled())
             {
                 logger.debug(logPrefix + "... done");
+            }
+
+            if (aom != null)
+            {
+            // Stop the AOM removal queue.
+                aom.aomRemoval.end ();
             }
 
             /* etherialize all active objects */

--- a/src/org/jacorb/poa/RequestProcessor.java
+++ b/src/org/jacorb/poa/RequestProcessor.java
@@ -24,6 +24,7 @@ import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
 import org.jacorb.config.*;
+import org.jacorb.poa.util.ByteArrayKey;
 import org.slf4j.Logger;
 import org.jacorb.orb.SystemExceptionHelper;
 import org.jacorb.orb.dsi.ServerRequest;
@@ -219,7 +220,7 @@ public class RequestProcessor
         try
         {
 
-            servant = controller.getAOM().incarnate( request.objectId(),
+            servant = controller.getAOM().incarnate( new ByteArrayKey(request.objectId()),
                                                      (ServantActivator) servantManager,
                                                      controller.getPOA());
             if (servant == null)


### PR DESCRIPTION
We had some problems with an application which is using Corba in JBoss AS7. For every request an AOMRemoval thread was started but never terminated. This lead to an OutOfMemoryError. I saw that in a newer version of JacORB, this issue was already fixed ("3.0 beta 1 - Modify AOMRemoval thread to shutdown on POA shutdown").

So I merged changes of AOM, POA from commit 0d1453c83da99e7ecd888d09e5b610ac606d69c2 and replaced the module in JBoss. After that I could not reproduce the problem anymore.

This may also solve this issue https://issues.jboss.org/browse/WFLY-806

Please review the changes before merge.
