### PR TITLE
BZ958: Improve application interaction with CDROutputStream. Added size-...

### DIFF
--- a/doc/REL_NOTES
+++ b/doc/REL_NOTES
@@ -43,6 +43,10 @@
     - ORB
          - Fix for built-in interceptors and local calls (BZ956/957).
            Add new isLocalInterceptors to *RequestInfoImpl Public API
+         - Add fix to prevent non-compilant buffers from being returned to the buffer manager (BZ958).
+         - Add public ctor to CDROutputStream to allow specifying a predetermined buffer size,
+           as well as a releaseBuffer method to let the application take ownership of the buffer
+           from the stream for use after the stream goes out of scope. (BZ958)
     - Misc
          - Improve Version output to incorporate the SHA (and autogenerate).
 3.3beta
@@ -59,7 +63,6 @@
          - Add fix for rootpoa creation with bad socket (BZ943).
          - Add fix for non_existent (BZ953).
          - Add fix for rewrite on OutputStream with large sizes (BZ941).
-         - Add fix to prevent non-compilant buffers from being returned to the buffer manager (BZ958).
 
     - POA
          - Add fix for exception in interceptors breaking requestprocesor thread. (BZ946)

--- a/test/regression/src/org/jacorb/test/orb/CDROutputStreamTest.java
+++ b/test/regression/src/org/jacorb/test/orb/CDROutputStreamTest.java
@@ -55,6 +55,20 @@ public class CDROutputStreamTest extends ORBTestCase
 
 
     /**
+     * Verifies that the public ctor is available and that the releaseBuffer works as expected
+     */
+    public void testCDRStreamSizeCtor()
+    {
+        CDROutputStream co = new CDROutputStream (orb, 1000, false);
+
+        co.increaseSize(8);
+
+        byte[] result = co.releaseBuffer();
+
+        assertTrue (result.length == 1023);
+    }
+
+    /**
      * Verifies that the default encoding (ISO8859_1) works for char, char arrays, and strings. Reading the string
      * forces alignment of the 4-byte length, and ignores any null terminator.
      */


### PR DESCRIPTION
...specifying constructor and a releaseBuffer method to allow application to use the buffer after the stream goes out of scope. Patch from Phil Mesnier
