### PR TITLE
Added missing comma

### DIFF
--- a/idl/omg/CORBA_InterfaceRepository.idl
+++ b/idl/omg/CORBA_InterfaceRepository.idl
@@ -196,7 +196,7 @@ interface Container : IRObject {
       in InterfaceDefSeq              base_interfaces
 #ifndef JACORB
       // Removed: http://www.omg.org/issues/issue3015.txt
-      in boolean                      is_abstract
+      ,in boolean                      is_abstract
 #endif
     );
    ValueDef create_value(


### PR DESCRIPTION
The IDL parser trips over this line if JACORB isn't defined.

I'm not an expert on the ORB, but this looks straight forward.  Here it is if it makes sense.
