### PR TITLE
Fixed smaller typos

### DIFF
--- a/doc/ProgrammingGuide/OBV/obv.tex
+++ b/doc/ProgrammingGuide/OBV/obv.tex
@@ -110,7 +110,7 @@ achieved by ``boxing'' primitive IDL types is {\em sharing} of values.
 With primitive values, two variables can have copies of the same
 value, but they cannot both refer to the same value. This means that
 when one of the variables is changed, the other one retains its
-orignal value. With shared values that are {\em referenced}, both
+original value. With shared values that are {\em referenced}, both
 variables would always point to the same value.
 
 The stateful value type {\tt Node} is implemented by the programmer in
@@ -205,7 +205,7 @@ but since they are ``factories'', the corresponding methods must also
 be implemented in the type's {\tt ValueFactory} implementation.
 
 
-%%% Local Variables: 
+%%% Local Variables:
 %%% mode: latex
 %%% TeX-master: "../ProgrammingGuide"
-%%% End: 
+%%% End:

--- a/doc/ProgrammingGuide/TransportCurrent/transportcurrent.tex
+++ b/doc/ProgrammingGuide/TransportCurrent/transportcurrent.tex
@@ -1,5 +1,5 @@
 %
-% $Id$ 
+% $Id$
 %
 
 Using the org.jacorb.transport.Current Feature
@@ -8,37 +8,37 @@ Using the org.jacorb.transport.Current Feature
 
 \section{Scope and Context}
 
-There is no standard-mandated mechanism to facilitate obtaining statistical or pretty 
-much any operational information about the network transport which the ORB is using. 
-While this is a direct corollary of the CORBA's design paradigm which mandates hiding 
-all this hairy stuff behind non-transparent abstractions, it also precludes effective 
-ORB and network monitoring. 
+There is no standard-mandated mechanism to facilitate obtaining statistical or pretty
+much any operational information about the network transport which the ORB is using.
+While this is a direct corollary of the CORBA's design paradigm which mandates hiding
+all this hairy stuff behind non-transparent abstractions, it also precludes effective
+ORB and network monitoring.
 
-The Transport::Current feature intends to fill this gap by defining a framework 
-for developing a wide range of solutions to this problem. It also provides a basic 
-implementation for the most common case - the IIOP transport. 
+The Transport::Current feature intends to fill this gap by defining a framework
+for developing a wide range of solutions to this problem. It also provides a basic
+implementation for the most common case - the IIOP transport.
 
-By definition, transport-specific information is available in contexts where the 
+By definition, transport-specific information is available in contexts where the
 ORB has selected a Transport:
 
 \begin{itemize}
-\item Within Client-side interception points; 
-\item Within Server-side interception points; 
-\item Inside a Servant up-call 
+\item Within Client-side interception points;
+\item Within Server-side interception points;
+\item Inside a Servant up-call
 \end{itemize}
 
-The implementation is based on a generic service-oriented framework, implementing 
-the Transport::Current interface. It is an optional service, which can be dynamically l
-oaded. This service makes the Transport::Current interface available through 
-orb->resolve\_initial\_references() . The basic idea is simple - whenever a Transport 
-is chosen by the ORB, the Transport::Current (or a protocolo-specific derivative) 
-will have access to that instance and be able to provide some useful information. 
+The implementation is based on a generic service-oriented framework, implementing
+the Transport::Current interface. It is an optional service, which can be dynamically
+loaded. This service makes the Transport::Current interface available through
+{\tt orb->resolve\_initial\_references()}. The basic idea is simple - whenever a Transport
+is chosen by the ORB, the Transport::Current (or a protocol-specific derivative)
+will have access to that instance and be able to provide some useful information.
 
 
 
 \section{Programmer's Reference}
 
-Consider the following IDL interface to access transport-specific data. 
+Consider the following IDL interface to access transport-specific data.
 
 \begin{verbatim}
 module org
@@ -89,8 +89,8 @@ module org
 };
 \end{verbatim}
 
-As an example of a specialized Transport::Current is the Transport::IIOP::Current, 
-which derives from Transport::Current and has an interface, described in the following IDL: 
+As an example of a specialized Transport::Current is the Transport::IIOP::Current,
+which derives from Transport::Current and has an interface, described in the following IDL:
 
 \begin{verbatim}
 module org
@@ -144,22 +144,22 @@ module org
 
 \section{User's Guide}
 
-The org.jacorb.transport.Current can be used as a base interface for a more 
-specialized interfaces. Iowever, it is not required that a more specialized 
-Current inherits from it. 
+The org.jacorb.transport.Current can be used as a base interface for a more
+specialized interfaces. However, it is not required that a more specialized
+Current inherits from it.
 
-Typical, generic usage is shown in the 
-tests/regression/src/org/jacorb/test/transport/IIOPTester.java test: 
+Typical, generic usage is shown in the
+tests/regression/src/org/jacorb/test/transport/IIOPTester.java test:
 
 \begin{verbatim}
 ...
    // Get the Current object.
-   Object tcobject = 
+   Object tcobject =
       orb.resolve_initial_references ("JacOrbIIOPTransportCurrent");
    Current tc = CurrentHelper.narrow (tcobject);
 
    logger.info("TC: ["+tc.id()+"] from="+tc.local_host() +":"
-                + tc.local_port() +", to=" 
+                + tc.local_port() +", to="
                 +tc.remote_host()+":"+tc.remote_port());
 
    logger.info("TC: ["+tc.id()+"] sent="+tc.messages_sent ()
@@ -172,9 +172,9 @@ tests/regression/src/org/jacorb/test/transport/IIOPTester.java test:
 \subsection{Configuration, Bootstrap, Initialization and Operation}
 
 
-To use the Transport Current features the framework must be loaded 
-through the Service Configuration framework. For example, using something 
-like this: 
+To use the Transport Current features the framework must be loaded
+through the Service Configuration framework. For example, using something
+like this:
 
 \begin{verbatim}
 ...
@@ -193,7 +193,7 @@ like this:
 ...
 \end{verbatim}
 
-The ORB initializer registers the "JacORbIIOPTransportCurrent" name with the orb, 
-so that it could be resolved via orb->resolve\_initial\_references("JacORbIIOPTransportCurrent"). 
+The ORB initializer registers the "JacORbIIOPTransportCurrent" name with the orb,
+so that it could be resolved via {\tt orb->resolve\_initial\_references("JacORbIIOPTransportCurrent")}.
 
-Note that any number of transport-specific Current interfaces may be available at any one time. 
+Note that any number of transport-specific Current interfaces may be available at any one time.


### PR DESCRIPTION
```
* doc/ProgrammingGuide/OBV/obv.tex:
* doc/ProgrammingGuide/TransportCurrent/transportcurrent.tex:
```
