### PR TITLE
Compute the size of fragmented responses

### DIFF
--- a/core/src/main/java/org/jacorb/orb/giop/Messages.java
+++ b/core/src/main/java/org/jacorb/orb/giop/Messages.java
@@ -198,6 +198,24 @@ public class Messages
         return readULong( buf, 8, isLittleEndian( buf ) );
     }
 
+    public static final void setMsgSize( byte[] buf, int size )
+    {
+        if ( isLittleEndian( buf ) )
+        {
+            buf[8]  = (byte)((size >> 24) & 0xFF);
+            buf[9]  = (byte)((size >> 16) & 0xFF);
+            buf[10] = (byte)((size >>  8) & 0xFF);
+            buf[11] = (byte) (size        & 0xFF);
+        }
+        else
+        {
+            buf[8]  = (byte) (size        & 0xFF);
+            buf[9]  = (byte)((size >>  8) & 0xFF);
+            buf[10] = (byte)((size >> 16) & 0xFF);
+            buf[11] = (byte)((size >> 24) & 0xFF);
+        }
+    }
+
     public static final int readULong( byte[] buf,
                                        int pos,
                                        boolean little_endian )


### PR DESCRIPTION
When `GIOPConnection` returns a response built from multiple fragments, it sets its size to the size of the first fragment.

This patch fixes this behavior so that the size of combined response is computed correctly (as sum of fragments' sizes). As a result, if an AMI CORBA call happens to result in an exception (returned in fragments), `ReplyInputStream.getBody()` call inside `ExceptionHolderImpl` constructor works correctly, instead of throwing `NegativeArraySizeException`.