### PR TITLE
Compute the size of fragmented responses

### DIFF
--- a/core/src/main/java/org/jacorb/orb/giop/ClientGIOPConnection.java
+++ b/core/src/main/java/org/jacorb/orb/giop/ClientGIOPConnection.java
@@ -132,6 +132,7 @@ public class ClientGIOPConnection
         // If the transport and/or connection has been closed there is no point
         // in keeping the fragments around.
         fragments.clear();
+        fragmentsSize.clear();
     }
 
     /**

--- a/core/src/main/java/org/jacorb/orb/giop/Messages.java
+++ b/core/src/main/java/org/jacorb/orb/giop/Messages.java
@@ -198,6 +198,24 @@ public class Messages
         return readULong( buf, 8, isLittleEndian( buf ) );
     }
 
+    public static final void setMsgSize( byte[] buf, int size )
+    {
+        if ( isLittleEndian( buf ) )
+        {
+            buf[8]  = (byte)((size >> 24) & 0xFF);
+            buf[9]  = (byte)((size >> 16) & 0xFF);
+            buf[10] = (byte)((size >>  8) & 0xFF);
+            buf[11] = (byte) (size        & 0xFF);
+        }
+        else
+        {
+            buf[8]  = (byte) (size        & 0xFF);
+            buf[9]  = (byte)((size >>  8) & 0xFF);
+            buf[10] = (byte)((size >> 16) & 0xFF);
+            buf[11] = (byte)((size >> 24) & 0xFF);
+        }
+    }
+
     public static final int readULong( byte[] buf,
                                        int pos,
                                        boolean little_endian )

--- a/core/src/main/java/org/jacorb/orb/giop/Messages.java
+++ b/core/src/main/java/org/jacorb/orb/giop/Messages.java
@@ -202,17 +202,17 @@ public class Messages
     {
         if ( isLittleEndian( buf ) )
         {
-            buf[8]  = (byte)((size >> 24) & 0xFF);
-            buf[9]  = (byte)((size >> 16) & 0xFF);
-            buf[10] = (byte)((size >>  8) & 0xFF);
-            buf[11] = (byte) (size        & 0xFF);
-        }
-        else
-        {
             buf[8]  = (byte) (size        & 0xFF);
             buf[9]  = (byte)((size >>  8) & 0xFF);
             buf[10] = (byte)((size >> 16) & 0xFF);
             buf[11] = (byte)((size >> 24) & 0xFF);
+        }
+        else
+        {
+            buf[8]  = (byte)((size >> 24) & 0xFF);
+            buf[9]  = (byte)((size >> 16) & 0xFF);
+            buf[10] = (byte)((size >>  8) & 0xFF);
+            buf[11] = (byte) (size        & 0xFF);
         }
     }
 

--- a/test/regression/pom.xml
+++ b/test/regression/pom.xml
@@ -131,6 +131,12 @@
             <scope>system</scope>
             <systemPath>${toolsjar}</systemPath>
         </dependency>
+        <dependency>
+        	<groupId>org.mockito</groupId>
+        	<artifactId>mockito-all</artifactId>
+        	<version>1.10.19</version>
+        	<scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/test/regression/src/test/java/org/jacorb/test/orb/giop/GIOPConnectionTest.java
+++ b/test/regression/src/test/java/org/jacorb/test/orb/giop/GIOPConnectionTest.java
@@ -1,0 +1,109 @@
+package org.jacorb.test.orb.giop;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.io.ByteArrayOutputStream;
+
+import org.jacorb.config.Configuration;
+import org.jacorb.orb.giop.ClientGIOPConnection;
+import org.jacorb.orb.giop.GIOPConnection;
+import org.jacorb.orb.giop.Messages;
+import org.jacorb.orb.giop.ReplyListener;
+import org.jacorb.test.harness.ORBTestCase;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.omg.ETF.BufferHolder;
+import org.omg.ETF.Connection;
+import org.slf4j.LoggerFactory;
+
+public class GIOPConnectionTest extends ORBTestCase
+{
+    @Test
+    public void testCorrectFragmentedResponseSize() throws Exception
+    {
+        // Prepare data on the wire
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        baos.write("GIOP".getBytes());       // magic
+        baos.write(1);                       // major: 1
+        baos.write(2);                       // minor: 2
+        baos.write(2);                       // more fragments, big endian (0000 0010)
+        baos.write(1);                       // type: Response
+        baos.write(new byte[]{0, 0, 0, 11}); // size
+        baos.write(new byte[]{0, 0, 0, 0});  // request ID
+        baos.write(new byte[]{0, 0, 0, 0});  // no service context
+        baos.write("foo".getBytes());        // content
+
+        baos.write("GIOP".getBytes());       // magic
+        baos.write(1);                       // major: 1
+        baos.write(2);                       // minor: 2
+        baos.write(1);                       // no more fragments, little endian (0000 0001)
+        baos.write(7);                       // type: Fragment
+        baos.write(new byte[]{10, 0, 0, 0}); // size
+        baos.write(new byte[]{0, 0, 0, 0});  // request ID
+        baos.write("barbaz".getBytes());     // content
+
+        final byte[] buffer = baos.toByteArray();
+
+        Connection transport = mock(Connection.class);
+        when(transport.is_connected())
+            .thenReturn(true);
+        when(transport.read(any(BufferHolder.class), anyInt(), anyInt(), anyInt(), anyLong()))
+            .thenAnswer(new TransportAnswer(buffer));
+
+        Configuration config = mock(Configuration.class);
+        when(config.getORB())
+            .thenReturn(getORB());
+        when(config.getLogger(anyString()))
+            .thenReturn(LoggerFactory.getLogger(GIOPConnectionTest.class));
+        when(config.getAttributeAsBoolean(matches(".*\\.disconnect_after_systemexception"), anyBoolean()))
+            .thenReturn(true);
+
+        ReplyListener listener = mock(ReplyListener.class);
+
+        GIOPConnection conn = new ClientGIOPConnection(null, transport, null, listener, null);
+        conn.configure(config);
+
+        // Read the wire
+        conn.receiveMessages();
+
+        // Single message received, correct size
+        ArgumentCaptor<byte[]> arg = ArgumentCaptor.forClass(byte[].class);
+
+        verify(listener)
+            .replyReceived(arg.capture(), eq(conn));
+
+        assertEquals(1,  Messages.getMsgType(arg.getValue()));
+        assertEquals(17, Messages.getMsgSize(arg.getValue()));
+    }
+
+    static class TransportAnswer implements Answer<Integer>
+    {
+        TransportAnswer(byte[] buffer)
+        {
+            this.buffer = buffer;
+        }
+
+        @Override
+        public Integer answer(InvocationOnMock inv) throws Throwable
+        {
+            if (buffer.length <= readIndex)
+                throw new org.omg.CORBA.COMM_FAILURE();
+
+            BufferHolder holder = inv.getArgumentAt(0, BufferHolder.class);
+            int offset          = inv.getArgumentAt(1, Integer.class);
+            int minLength       = inv.getArgumentAt(2, Integer.class);
+
+            System.arraycopy(buffer, readIndex, holder.value, offset, minLength);
+            readIndex += minLength;
+
+            return minLength;
+        }
+
+        private byte[] buffer;
+        int readIndex = 0;
+    }
+}


### PR DESCRIPTION
When `GIOPConnection` returns a response built from multiple fragments, it sets its size to the size of the first fragment.

This patch fixes this behavior so that the size of combined response is computed correctly (as sum of fragments' sizes). As a result, if an AMI CORBA call happens to result in an exception (returned in fragments), `ReplyInputStream.getBody()` call inside `ExceptionHolderImpl` constructor works correctly, instead of throwing `NegativeArraySizeException`.