### PR TITLE
Fix test failure triggered by earlier codeset change

### DIFF
--- a/core/src/main/java/org/jacorb/orb/CodeSet.java
+++ b/core/src/main/java/org/jacorb/orb/CodeSet.java
@@ -71,10 +71,11 @@ public class CodeSet
     static final CodeSet UCS2_CODESET = new Ucs2CodeSet();
 
     static final CodeSet MAC_ROMAN_CODESET = new MacRomanCodeSet();
+
     /**
      * All of the encodings supported by Jacorb. These should be listed in order of preference.
      */
-  static final CodeSet[] KNOWN_ENCODINGS = { ISO8859_1_CODESET, ISO8859_15_CODESET, UTF16_CODESET, UTF8_CODESET, UCS2_CODESET, MAC_ROMAN_CODESET, ASCII_CODESET };
+    static final CodeSet[] KNOWN_ENCODINGS = { ISO8859_1_CODESET, ISO8859_15_CODESET, UTF16_CODESET, UTF8_CODESET, UCS2_CODESET, MAC_ROMAN_CODESET, ASCII_CODESET };
 
     /**
      * The default JVM platform encoding.

--- a/core/src/main/java/org/jacorb/orb/CodeSet.java
+++ b/core/src/main/java/org/jacorb/orb/CodeSet.java
@@ -74,7 +74,7 @@ public class CodeSet
     /**
      * All of the encodings supported by Jacorb. These should be listed in order of preference.
      */
-    static final CodeSet[] KNOWN_ENCODINGS = { ASCII_CODESET, ISO8859_1_CODESET, ISO8859_15_CODESET, UTF16_CODESET, UTF8_CODESET, UCS2_CODESET, MAC_ROMAN_CODESET };
+  static final CodeSet[] KNOWN_ENCODINGS = { ISO8859_1_CODESET, ISO8859_15_CODESET, UTF16_CODESET, UTF8_CODESET, UCS2_CODESET, MAC_ROMAN_CODESET, ASCII_CODESET };
 
     /**
      * The default JVM platform encoding.
@@ -368,7 +368,6 @@ public class CodeSet
     {
         return name;
     }
-
 
     @Override
     public String toString ()


### PR DESCRIPTION
This serves as a gentle reminder to always run the full regression test suite after even "trivial" changes. 

Note that the test failed was an identity test. The issue at hand is one of aliases. The change I introduced silenced myriad warnings that occur on systems that use a locale that serves up a Latin-1 equivalent codeset but with a different name. While I believe what I've done is good enough since the ORB code that is involved gets the local Codeset name and maps that to an identifier that is serialized for transmission. On the receiving side, the serialized Codeset identifier is used directly, no name matching is involved. 
