### PR TITLE
Update the cipher to continue working with Java 8, SSL_RSA_WITH_RC4_1…

### DIFF
--- a/test/regression/src/test/java/org/jacorb/test/bugs/bugjac563/BugJac563Test.java
+++ b/test/regression/src/test/java/org/jacorb/test/bugs/bugjac563/BugJac563Test.java
@@ -71,7 +71,7 @@ public class BugJac563Test extends ClientServerTestCase
         clientProps.setProperty("jacorb.ssl.socket_factory", "org.jacorb.security.ssl.sun_jsse.SSLSocketFactory");
         clientProps.setProperty("jacorb.ssl.server_socket_factory", "org.jacorb.security.ssl.sun_jsse.SSLServerSocketFactory");
 
-        clientProps.setProperty("jacorb.security.ssl.client.cipher_suites", "SSL_RSA_WITH_RC4_128_MD5");
+        clientProps.setProperty("jacorb.security.ssl.client.cipher_suites", "TLS_RSA_WITH_AES_128_CBC_SHA");
 
         if (TestUtils.isIBM)
         {


### PR DESCRIPTION
…28_MD5 is apparently obsolete, at least on OSX