### PR TITLE
Bug 1014: Multhreading issues in ForwardRequest/LocationForward handling

### DIFF
--- a/core/src/main/java/org/jacorb/orb/Delegate.java
+++ b/core/src/main/java/org/jacorb/orb/Delegate.java
@@ -1314,7 +1314,8 @@ public final class Delegate
         }
 
         ClientConnection connectionToUse = null;
-
+        try
+        {
         ReplyGroup group = null;
         try
         {
@@ -1330,6 +1331,7 @@ public final class Delegate
                   // RequestOutputStream has been created for
                   // exactly this connection
                   connectionToUse = connections[currentConnection.ordinal ()];
+                  connectionToUse.incClients(); // bug1014: avoid close after rebind
                }
                else
                {
@@ -1485,6 +1487,14 @@ public final class Delegate
             disconnect(connectionToUse);
 
             throw e;
+        }
+        }
+        finally
+        {
+            if (connectionToUse != null)
+            {
+                conn_mg.releaseConnection(connectionToUse); // bug1014: let it be closed
+            }
         }
 
         return null;

--- a/test/regression/src/test/idl/bug1014.idl
+++ b/test/regression/src/test/idl/bug1014.idl
@@ -1,0 +1,20 @@
+module org
+{
+    module jacorb
+    {
+        module test
+        {
+            module bugs
+            {
+                module bug1014
+                {
+                    interface DeniedService {
+
+                        void resetWhenReach(in long limit);
+
+                    };
+                };
+            };
+        };
+    };
+};

--- a/test/regression/src/test/java/org/jacorb/test/bugs/bug1012/Bug1012Test.java
+++ b/test/regression/src/test/java/org/jacorb/test/bugs/bug1012/Bug1012Test.java
@@ -41,7 +41,7 @@ public class Bug1012Test extends ClientServerTestCase
         expected = new HashMap<TestCase, int[]>();
 
         expected.put(TestCase.WorkJustFine, new int[]{3,2,0});
-        expected.put(TestCase.ExtraCall, new int[]{5,3,2});
+        expected.put(TestCase.ExtraCall, new int[]{4,2,2});
         expected.put(TestCase.DequePop, new int[]{5,2,0});
 
         Properties props = new Properties();

--- a/test/regression/src/test/java/org/jacorb/test/bugs/bug1014/Bug1014Test.java
+++ b/test/regression/src/test/java/org/jacorb/test/bugs/bug1014/Bug1014Test.java
@@ -1,0 +1,74 @@
+package org.jacorb.test.bugs.bug1014;
+
+import java.util.Properties;
+import org.jacorb.test.bugs.bug1014.DeniedService;
+import org.jacorb.test.bugs.bug1014.DeniedServiceHelper;
+import org.jacorb.test.harness.ClientServerSetup;
+import org.jacorb.test.harness.ClientServerTestCase;
+import org.jacorb.test.harness.IMRExcludedClientServerCategory;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.omg.CORBA.NO_PERMISSION;
+
+@Category(IMRExcludedClientServerCategory.class)
+public class Bug1014Test extends ClientServerTestCase {
+
+	@BeforeClass
+	public static void beforeClassSetup() throws Exception {
+		Properties props = new Properties();
+		props.setProperty(
+				"org.omg.PortableInterceptor.ORBInitializerClass.ORBInit",
+				ORBInit.class.getName());
+		setup = new ClientServerSetup(Servant.class.getName(), props, props);
+	}
+
+	@Test
+	public void testConcurrentCalls() {
+		final DeniedService service =
+				DeniedServiceHelper.narrow(setup.getServerObject());
+		Runnable task = new Runnable () {
+			public void run() { service.resetWhenReach(10); }
+		};
+		ManyThreads threads = new ManyThreads(5, task);
+		Assert.assertTrue(threads.checkCompletion(5000));
+	}
+
+	private static class ManyThreads {
+		private final java.lang.Object sync;
+		private final Runnable task;
+		private int missing;
+
+		public ManyThreads(int count, Runnable runnable) {
+			sync = new java.lang.Object();
+			task = runnable;
+			missing = count;
+			for (int i = 0; i < count; ++i) {
+				Thread t = new Thread(new Runnable () {
+					public void run() {
+						task.run();
+						synchronized (sync) {
+							if (--missing == 0) {
+								sync.notifyAll();
+							}
+						}
+					}
+				});
+				t.start();
+			}
+		}
+
+		public boolean checkCompletion(int timeout) {
+			synchronized (sync) {
+				if (missing > 0) {
+					try { sync.wait(timeout); }
+					catch (InterruptedException ex) {}
+				}
+				if (missing == 0) return true;
+			}
+			return false;
+		}
+	}
+}

--- a/test/regression/src/test/java/org/jacorb/test/bugs/bug1014/ORBInit.java
+++ b/test/regression/src/test/java/org/jacorb/test/bugs/bug1014/ORBInit.java
@@ -1,0 +1,46 @@
+package org.jacorb.test.bugs.bug1014;
+
+import org.omg.CORBA.LocalObject;
+import org.omg.CORBA.NO_PERMISSIONHelper;
+import org.omg.PortableInterceptor.ClientRequestInfo;
+import org.omg.PortableInterceptor.ClientRequestInterceptor;
+import org.omg.PortableInterceptor.ForwardRequest;
+import org.omg.PortableInterceptor.ORBInitializer;
+import org.omg.PortableInterceptor.ORBInitInfo;
+import org.omg.PortableInterceptor.ORBInitInfoPackage.DuplicateName;
+
+public class ORBInit extends LocalObject
+                                       implements ORBInitializer {
+	public void pre_init(ORBInitInfo info) {
+		try {
+			info.add_client_request_interceptor(new RetryOnDenyInterceptor());
+		} catch (DuplicateName e) {
+			e.printStackTrace();
+		}
+	}
+
+	public void post_init(ORBInitInfo info) { /* empty */ }
+
+	private static class RetryOnDenyInterceptor extends LocalObject
+	                                            implements ClientRequestInterceptor {
+
+		public void send_request(ClientRequestInfo ri) throws ForwardRequest { /* empty */ }
+
+		public void send_poll(ClientRequestInfo ri) { /* empty */ }
+
+		public void receive_reply(ClientRequestInfo ri) { /* empty */ }
+
+		public void receive_exception(ClientRequestInfo ri) throws ForwardRequest {
+			if (ri.received_exception_id().equals(NO_PERMISSIONHelper.id())) {
+				throw new ForwardRequest(ri.target());
+			}
+		}
+
+		public void receive_other(ClientRequestInfo ri) throws ForwardRequest { /* empty */ }
+
+		public String name() { return "my_client_interceptor"; }
+
+		public void destroy() { /* empty */ }
+
+	}
+}

--- a/test/regression/src/test/java/org/jacorb/test/bugs/bug1014/Servant.java
+++ b/test/regression/src/test/java/org/jacorb/test/bugs/bug1014/Servant.java
@@ -1,0 +1,15 @@
+package org.jacorb.test.bugs.bug1014;
+
+import org.omg.CORBA.NO_PERMISSION;
+
+public final class Servant extends DeniedServicePOA {
+  private int count = 0;
+
+  @Override
+  public synchronized void resetWhenReach(int limit) {
+    if (++count < limit) {
+      throw new NO_PERMISSION();
+    }
+    count = 0;
+  }
+}


### PR DESCRIPTION
A single instance of 'org.jacorb.orb.Delegate' can be used by multiple threads to perform invocations concurrently, which are sent using a 'ClientConnection' stored in an attribute of 'Delegate'. Eventually this 'ClientConnection' can be replaced due to the processing of a LocationForward (e.g. replied by the ImR) or a ForwardRequest (thrown by ClientInterceptors). In such cases, the replaced 'ClientConnection' is closed if it is not used by any other 'Delegate'. However if one thread is still waiting for a reply while the connection is replaced and closed (no clients left!) the pending requests will result in a incorrect 'COMM_FAILURE'.

A comment in 'Delegate.java' describes that 'bind_sync' is used to deal with this problem by means of thread synchronization. However, the synchronization using 'bind_sync' only guarantees that changing the 'ClientConnection' in a single 'Delegate' is done atomically, but does not address the scenario where the 'ClientConnection' is closed after being replaced but still having pending replies.

Bug 1014 reports this exact problem and it is still present in current HEAD at GitHub.

Another similar scenario, but which is much more difficult to reproduce in a test case, is that one 'ClientConnection' might be replaced and closed just after another thread gets a reference to the connection and is about to write on the connection. In such case, when the closed connection is used it automatically reconnects and but does not processes any incoming messages (due to 'GIOPConnection.do_close == true'), therefore the request is never answered and the calling thread freezes.

To avoid all these problems related to an concurrent close of a 'ClientConnection' while it is being used by other threads (to read replies or send requests) I tried to make that whenever a 'ClientConnection' is obtained to perform a request, its client reference count (ClientConnection.incClients) is increased. When the request is finally completed, the client couter is decreased (ClientConnection.decClients). This should avoid that the 'ClientConnection' be closed while in use to make a request.

I also added a test case for this bug 1014 and had to change test case for bug 1012 because it was broken by this proposed solution. The test case for bug 1012 seems to be a copy of the code provided to show some of the problems reported in bug 1012. Because of that I suspect such test case enforces some of the wrong behaviour (an extra call) that were intended to be reported in bug 1012. For this reason I suggest that someone take a better look at test case for bug 1012 or remove it from the test suite.

All that being said, I'd like to point out that such multithreading issues are more evident in the presence of a 'ForwardRequest' due to an inefficient behavior of JacORB's current implementation. This is mainly because it adopts the same semantics of a GIOP's Reply 'LOCATION_FORWARD_PERM' (like used to support the ImR) for a 'ForwardRequest'. This imples that every 'ForwardRequest' must replace the connection in the 'Delegate', and generally it is assumed that the new IOR is at a different location (i.e. different connection).

The scenario where this does not work very well is when 'ForwardRequest' is used to retry the request to the same target (e.g. with credential data embedded in a service context). In such case, multiple threads processing such 'ForwardRequest' on a single 'Delegate' basically compete replacing connections to the same target while trying to send requests using some of these connections that are being constantly closed and recreated. So, even with the proposed correction to allow that in such case the management of active connections is done right, it is still somewhat inefficient in the case where the target is always the same.

Nick Cross correctly pointed out to me a long time ago that such behavior does not conflict with the CORBA specs which indicates the application cannot make assumptions about how the object location is handled by the ORB (i.e. the forward is permant or not). However, such behavior might make the implementation a little more complex than necessary. To replace the "permanent" connection, we have to deal with the special case where the "forwarded" connection is the same, since in such case the connection should not be released if we don't want it to be closed. On the other hand, if we don't have to replace it, we could simply resolve the "forwarded" connection and send the request using this connection, whichever it is. If the IOR targets the same connection as the "permanent" one, the same connection will be probably recovered form the cache (ClientConnectionManager) and reused.