### PR TITLE
Pull request associated with bugzilla #1023 and #1090

### DIFF
--- a/core/src/main/java/org/jacorb/orb/TaggedComponentList.java
+++ b/core/src/main/java/org/jacorb/orb/TaggedComponentList.java
@@ -321,11 +321,11 @@ public class TaggedComponentList implements Cloneable
         TaggedComponent[] newComponents =
             new TaggedComponent [components.length - match_cnt];
 
-        for (int i=0; i < components.length; i++)
+        for (int i=0, n=0; i < components.length; i++)
         {
             if (components[i].tag != tag)
             {
-                newComponents[i] = components[i];
+                newComponents[n++] = components[i];
             }
         }
 

--- a/core/src/main/java/org/jacorb/orb/iiop/IIOPAddress.java
+++ b/core/src/main/java/org/jacorb/orb/iiop/IIOPAddress.java
@@ -45,7 +45,7 @@ public class IIOPAddress extends ProtocolAddressBase
 
     static
     {
-        networkVirtualInterfaces = System.getProperty("jacorb.network.virtual", "VirtualBox,VMWare,VMware,vboxnet,docker").split(",");
+        networkVirtualInterfaces = System.getProperty("jacorb.network.virtual", "VirtualBox,VMWare,VMware,virbr0,vboxnet,docker").split(",");
     }
 
     private String source_name = null; // initializing string


### PR DESCRIPTION
Add additional virtual adapter name "virbr0" to default "jacorb.network.virtual" system property and fix ArrayIndexOutOfBoundsException occuring in TaggedComponentList.removeComponents()