### PR TITLE
Fixes a bug that happes because of modifying a map while enumerating it

### DIFF
--- a/core/src/main/java/org/jacorb/naming/NamingContextImpl.java
+++ b/core/src/main/java/org/jacorb/naming/NamingContextImpl.java
@@ -726,21 +726,17 @@ public class NamingContextImpl
          * Recreate tables. For serialization, object references
          * have been transformed into strings
          */
-
-        for( Enumeration e = contexts.keys(); e.hasMoreElements();)
-        {
-            Name key = (Name)e.nextElement();
+        for (Object nameAsObject : contexts.keySet().toArray()) {
+            Name key = (Name)nameAsObject;
             String ref = (String)contexts.remove(key);
-            contexts.put( key, orb.string_to_object( ref ));
+            contexts.put(key, orb.string_to_object(ref));
         }
 
-        for( Enumeration e = names.keys(); e.hasMoreElements();)
-        {
-            Name key = (Name)e.nextElement();
+        for (Object nameAsObject : names.keySet().toArray()) {
+            Name key = (Name)nameAsObject;
             String ref = (String)names.remove(key);
-            names.put( key, orb.string_to_object( ref ));
+            names.put(key, orb.string_to_object(ref));
         }
-
     }
 
     /* NamingContextExt */


### PR DESCRIPTION
The bug happens randomly when deserializing NamingContextImpl resulting in a hashmap (names) that contains both Strings and corba Objects. One of the errors is shown below.

```
2017-04-25 16:22:50.696 SEVERE rid: 18 opname: resolve invocation: throwable was thrown.
java.lang.ClassCastException: java.lang.String cannot be cast to org.omg.CORBA.Object
	at org.jacorb.naming.NamingContextImpl.resolve(NamingContextImpl.java:592)
	at org.omg.CosNaming.NamingContextExtPOA._invoke(NamingContextExtPOA.java:325)
	at org.jacorb.poa.RequestProcessor.invokeOperation(RequestProcessor.java:402)
	at org.jacorb.poa.RequestProcessor.process(RequestProcessor.java:726)
	at org.jacorb.poa.RequestProcessor.run(RequestProcessor.java:884)
```

This might be bug BZ981.
Since I couldnt find out how to access JacORB Bugzilla, the only reference I found for the bug was http://lists.spline.inf.fu-berlin.de/pipermail/jacorb-bugs/2014-April/000257.html 
