### PR TITLE
Fixed a bug in NotificationService which caused ConcurrentModificationExceptions

### DIFF
--- a/services/src/main/java/org/jacorb/notification/FilterManager.java
+++ b/services/src/main/java/org/jacorb/notification/FilterManager.java
@@ -21,11 +21,11 @@ package org.jacorb.notification;
  *
  */
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.slf4j.Logger;
 import org.jacorb.notification.util.LogUtil;
@@ -53,7 +53,7 @@ public class FilterManager implements FilterAdminOperations
 
     private boolean filtersModified_;
 
-    private final List filterList_ = new ArrayList();
+    private final List filterList_ = new CopyOnWriteArrayList();
 
     private final List filtersReadOnlyView_ = Collections.unmodifiableList(filterList_);
 

--- a/services/src/main/java/org/jacorb/notification/servant/FilterStageListManager.java
+++ b/services/src/main/java/org/jacorb/notification/servant/FilterStageListManager.java
@@ -63,10 +63,6 @@ public abstract class FilterStageListManager
         {
             refreshNoLocking();
 
-            // as readOnlyView_ delegates to checkedList_ sorting
-            // will also affect the order of readOnlyView_
-            doSortCheckedList(checkedList_);
-
             return readOnlyView_;
         }
     }
@@ -97,6 +93,7 @@ public abstract class FilterStageListManager
             };
 
             fetchListData(_listProxy);
+            doSortCheckedList(_newList);
 
             checkedList_ = _newList;
             readOnlyView_ = Collections.unmodifiableList(checkedList_);

--- a/test/regression/src/test/java/org/jacorb/test/notification/servant/FilterStageListManagerTest.java
+++ b/test/regression/src/test/java/org/jacorb/test/notification/servant/FilterStageListManagerTest.java
@@ -1,0 +1,144 @@
+/*
+ *        JacORB - a free Java ORB
+ *
+ *   Copyright (C) 1999-2017 Gerald Brose / The JacORB Team.
+ *
+ *   This library is free software; you can redistribute it and/or
+ *   modify it under the terms of the GNU Library General Public
+ *   License as published by the Free Software Foundation; either
+ *   version 2 of the License, or (at your option) any later version.
+ *
+ *   This library is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *   Library General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Library General Public
+ *   License along with this library; if not, write to the Free
+ *   Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ */
+ package org.jacorb.test.notification.servant;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+
+import org.jacorb.notification.interfaces.FilterStage;
+import org.jacorb.notification.interfaces.MessageConsumer;
+import org.jacorb.notification.servant.FilterStageListManager;
+import org.junit.Test;
+import org.omg.CosNotifyFilter.MappingFilter;
+
+public class FilterStageListManagerTest {
+
+    @Test
+    public void gettingListShouldNotBreakFilterStageListManagerIfSortingIsDone()
+            throws InterruptedException {
+        FilterStageListManagerMock m = new FilterStageListManagerMock();
+        m.actionSourceModified();
+
+        Iterator it = m.getList().iterator();
+        it.next();
+
+        m.getList();
+
+        it.next();
+    }
+
+    private class FilterStageListManagerMock extends FilterStageListManager {
+        private final int arrSize = 100;
+
+        @Override
+        protected void fetchListData(FilterStageList listProxy) {
+            // This simulates the addition of 0 - 100 new filters.
+            Random r = new Random();
+            int max = new Float(r.nextFloat() * arrSize).intValue();
+            for (int i = 0; i < max; i++) {
+                listProxy.add(new FilterStageMock(i));
+            }
+        }
+
+        @Override
+        protected void doSortCheckedList(List list) {
+            // Sorting is done in ConsumerAdminImpl class also
+            List<FilterStage> stageList = list;
+            Collections.sort(stageList, new Comparator<FilterStage>() {
+                @Override
+                public int compare(FilterStage o1, FilterStage o2) {
+                    return o1.toString().compareTo(o1.toString());
+                }
+            });
+        }
+    }
+
+    private class FilterStageMock implements FilterStage {
+
+        private final int index;
+
+        @Override
+        public String toString() {
+            return "" + index;
+        }
+
+        public FilterStageMock(int index) {
+            this.index = index;
+        }
+
+        @Override
+        public List getSubsequentFilterStages() {
+            return null;
+        }
+
+        @Override
+        public boolean isDestroyed() {
+            return false;
+        }
+
+        @Override
+        public List getFilters() {
+            List filters = new ArrayList();
+            filters.add(index);
+            return filters;
+        }
+
+        @Override
+        public boolean hasMessageConsumer() {
+            return false;
+        }
+
+        @Override
+        public boolean hasInterFilterGroupOperatorOR() {
+            return false;
+        }
+
+        @Override
+        public MessageConsumer getMessageConsumer() {
+            return null;
+        }
+
+        @Override
+        public boolean hasLifetimeFilter() {
+            return false;
+        }
+
+        @Override
+        public boolean hasPriorityFilter() {
+            return false;
+        }
+
+        @Override
+        public MappingFilter getLifetimeFilter() {
+            return null;
+        }
+
+        @Override
+        public MappingFilter getPriorityFilter() {
+            return null;
+        }
+
+    }
+}


### PR DESCRIPTION
I fixed a bug where adding a new message filter or filter matching in NotificationService caused ConcurrentModificationException while iterating filters. 

Following warning was logged when iterating filters failed:

WARN StructuredEventMessage:565 - unexpected error during match. match result defaults to false
java.util.ConcurrentModificationException
    at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:901) ~[?:1.8.0_51]
    at java.util.ArrayList$Itr.next(ArrayList.java:851) ~[?:1.8.0_51]
    at java.util.Collections$UnmodifiableCollection$1.next(Collections.java:1042) ~[?:1.8.0_51]
    at org.jacorb.notification.AbstractMessage.match(AbstractMessage.java:551) [?:3.7]
    at org.jacorb.notification.AbstractMessage$MessageHandle.match(AbstractMessage.java:241) [?:3.7]
    at org.jacorb.notification.engine.FilterProxySupplierTask.filter(FilterProxySupplierTask.java:221) [?:3.7]
    at org.jacorb.notification.engine.FilterProxySupplierTask.doFilter(FilterProxySupplierTask.java:117) [?:3.7]
    at org.jacorb.notification.engine.AbstractFilterTask.doWork(AbstractFilterTask.java:76) [?:3.7]
    at org.jacorb.notification.engine.AbstractTask.run(AbstractTask.java:63) [?:3.7]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [?:1.8.0_51]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [?:1.8.0_51]
    at java.lang.Thread.run(Thread.java:745) [?:1.8.0_51]


Another problem was that sorting filters while adding new filter threw ConcurrentModificationException:

ERROR FilterConsumerAdminTask:148 - Error while Filtering in Task:FilterConsumerAdminTask#3483
java.util.ConcurrentModificationException
    at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:901) ~[?:1.8.0_51]
    at java.util.ArrayList$Itr.next(ArrayList.java:851) ~[?:1.8.0_51]
    at java.util.Collections$UnmodifiableCollection$1.next(Collections.java:1042) ~[?:1.8.0_51]
    at org.jacorb.notification.engine.AbstractFilterTask.addFilterStage(AbstractFilterTask.java:105) ~[?:3.7]
    at org.jacorb.notification.engine.FilterConsumerAdminTask.filter(FilterConsumerAdminTask.java:137) ~[?:3.7]
    at org.jacorb.notification.engine.FilterConsumerAdminTask.doFilter(FilterConsumerAdminTask.java:82) ~[?:3.7]
    at org.jacorb.notification.engine.AbstractFilterTask.doWork(AbstractFilterTask.java:76) [?:3.7]
    at org.jacorb.notification.engine.AbstractTask.run(AbstractTask.java:63) [?:3.7]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [?:1.8.0_51]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [?:1.8.0_51]
    at java.lang.Thread.run(Thread.java:745) [?:1.8.0_51]

I wrote also a test for FilterManager but it is more like a system test with requirements for concurrency. It is not included to source control.

[FilterManagerTest.zip](https://github.com/JacORB/JacORB/files/1108609/FilterManagerTest.zip)

