### PR TITLE
In JacORB versions 3.4 and earlier, java OutOfMemoryErrors caused by …

### DIFF
--- a/core/src/main/java/org/jacorb/orb/giop/GIOPConnection.java
+++ b/core/src/main/java/org/jacorb/orb/giop/GIOPConnection.java
@@ -889,30 +889,30 @@ public abstract class GIOPConnection
 
     private void receiveMessagesLoop() throws IOException
     {
-		if ( catch_oom )
-		{
-			try
-        	{
-				receiveMessagesLoopImpl();
-			}
-	        // this should be catch out of memory
-        	catch (NO_MEMORY e)
-        	{
-	            logger.error ("Caught NO_MEMORY error", e);
+        if ( catch_oom )
+        {
+            try
+            {
+                receiveMessagesLoopImpl();
+            }
+            // this should be catch out of memory
+            catch (NO_MEMORY e)
+            {
+                logger.error ("Caught NO_MEMORY error", e);
 
-            	streamClosed();
-        	}
-        	catch (OutOfMemoryError e)
-        	{
-	            logger.error ("Caught OutOfMemory error", e);
+                streamClosed();
+            }
+            catch (OutOfMemoryError e)
+            {
+                logger.error ("Caught OutOfMemory error", e);
 
-    	        streamClosed();
-        	}
-		}
-		else	// do not catch errors
-		{
-			receiveMessagesLoopImpl();
-		}
+            streamClosed();
+            }
+        }
+        else	// do not catch errors
+        {
+            receiveMessagesLoopImpl();
+        }
     }
 
     // timeout is in milliseconds and is an interval

--- a/etc/jacorb_properties.template
+++ b/etc/jacorb_properties.template
@@ -233,6 +233,13 @@ jacorb.connection.client.connect_timeout=90000
 # the lost request on the server.
 #jacorb.connection.client.retry_on_failure=off
 
+# In JacORB versions 3.4 and earlier, java OutOfMemoryErrors caused by receiving very large messages were not caught,
+# and the application code would need to handle them.
+# Starting with version 3.5, JacORB catches these errors, outputs a COMM_FAILURE, and logs the out of memory.
+# This can guard the application from these errors, however it may be difficult for the user to determine the cause of the COMM_FAILURE.
+# To revert back to the original implementation, set catch_out_of_memory to false.  Default is true.
+#jacorb.connection.catch_out_of_memory=true
+
 # max time (msecs) a server keeps a connection open if nothing happens
 #jacorb.connection.server.timeout=10000
 


### PR DESCRIPTION
…receiving very large messages were not caught,

and the application code would need to handle them.
Starting with version 3.5, JacORB catches these errors, outputs a COMM_FAILURE, and logs the out of memory.
This can guard the application from these errors, however it may be difficult for the user to determine the cause of the COMM_FAILURE.
This change reverts the operation of GIOPConnection.receiveMessagesLoop() back to the original implementation, IF jacorb.connection.catch_out_of_memory=false is
present in orb.properties.
The default value is true, meaning the ORB operates as before this change.
Changes to be committed:
modified:   core/src/main/java/org/jacorb/orb/giop/GIOPConnection.java
modified:   etc/jacorb_properties.template