### PR TITLE
Fixed issue #201 - exception when queue listeners are added

### DIFF
--- a/core/src/main/java/org/jacorb/poa/RequestQueue.java
+++ b/core/src/main/java/org/jacorb/poa/RequestQueue.java
@@ -67,6 +67,8 @@ public class RequestQueue
         queueMin = configuration.getAttributeAsInteger("jacorb.poa.queue_min", 10);
         queueWait = configuration.getAttributeAsBoolean("jacorb.poa.queue_wait",false);
 
+        configured = true;
+
         List queueListeners = configuration.getAttributeList("jacorb.poa.queue_listeners");
 
         for (Iterator i = queueListeners.iterator(); i.hasNext();)
@@ -84,8 +86,6 @@ public class RequestQueue
                                                   ex);
             }
         }
-
-        configured = true;
     }
 
     /**


### PR DESCRIPTION
Originally, when the queue listeners are added during configuration of the POA, the configured flag was false causing a BAD_INV_ORDER exception to be thrown in the addQueueListeners method.
Setting of the configured flag was moved before the queue listeners are added.