### PR TITLE
Issue unmarshalling user exception with Any

### DIFF
--- a/test/regression/src/test/idl/ExceptionServer.idl
+++ b/test/regression/src/test/idl/ExceptionServer.idl
@@ -12,6 +12,7 @@ module org
               string message;
           };
 
+
          interface ExceptionServer
          {
             void throwRuntimeException(in string message);
@@ -23,6 +24,9 @@ module org
 
             void throwUserExceptionWithMessage2(in string reason, in string message)
                raises (MyUserException);
+
+            void throwAnyException(in string reason, in any anything)
+               raises (AnyException);
          };
       };
    };

--- a/test/regression/src/test/idl/Tests.idl
+++ b/test/regression/src/test/idl/Tests.idl
@@ -26,6 +26,12 @@ module org
             string field2;
          };
 
+         // example Exception with any type
+         exception AnyException
+         {
+             any anything;
+         };
+
          // example unbounded Sequence
          typedef sequence< long > UnboundedData;
 

--- a/test/regression/src/test/idl/TimingServer.idl
+++ b/test/regression/src/test/idl/TimingServer.idl
@@ -10,6 +10,7 @@ module org
          {
             long operation (in long id, in long delay);
             char ex_op     (in char ch, in long delay) raises (EmptyException);
+            void any_ex_op (in string reason, in any anything, in long delay) raises (AnyException);
 
             long long server_time (in long delay);
          };

--- a/test/regression/src/test/java/org/jacorb/test/bugs/bug940/TimingServerImpl.java
+++ b/test/regression/src/test/java/org/jacorb/test/bugs/bug940/TimingServerImpl.java
@@ -1,7 +1,9 @@
 package org.jacorb.test.bugs.bug940;
 
+import org.jacorb.test.AnyException;
 import org.jacorb.test.EmptyException;
 import org.jacorb.test.TimingServerPOA;
+import org.omg.CORBA.Any;
 
 public class TimingServerImpl extends TimingServerPOA
 {
@@ -28,6 +30,13 @@ public class TimingServerImpl extends TimingServerPOA
         {
             return ch;
         }
+    }
+
+    @Override
+    public void any_ex_op(String reason, Any anything, int delay) throws AnyException
+    {
+        sleep(delay);
+        throw new AnyException(reason, anything);
     }
 
     @Override

--- a/test/regression/src/test/java/org/jacorb/test/bugs/bugjac493/TimingServerImpl.java
+++ b/test/regression/src/test/java/org/jacorb/test/bugs/bugjac493/TimingServerImpl.java
@@ -1,7 +1,9 @@
 package org.jacorb.test.bugs.bugjac493;
 
+import org.jacorb.test.AnyException;
 import org.jacorb.test.EmptyException;
 import org.jacorb.test.TimingServerPOA;
+import org.omg.CORBA.Any;
 
 public class TimingServerImpl extends TimingServerPOA
 {
@@ -26,6 +28,12 @@ public class TimingServerImpl extends TimingServerPOA
         {
             return ch;
         }
+    }
+
+    public void any_ex_op(String reason, Any anything, int delay) throws AnyException
+    {
+        sleep(delay);
+        throw new AnyException(reason, anything);
     }
 
     public long server_time(int delay)

--- a/test/regression/src/test/java/org/jacorb/test/bugs/bugjac493/TimingTest.java
+++ b/test/regression/src/test/java/org/jacorb/test/bugs/bugjac493/TimingTest.java
@@ -174,9 +174,19 @@ public class TimingTest extends CallbackTestCase
           wrong_exception ("ex_op_excep", excep_holder);
        }
 
+       public void any_ex_op_excep(ExceptionHolder excep_holder)
+       {
+          wrong_exception ("any_ex_op_excep", excep_holder);
+       }
+
        public void ex_op(char ami_return_val)
        {
           wrong_reply ("ex_op");
+       }
+
+       public void any_ex_op()
+       {
+          wrong_reply ("any_ex_op");
        }
 
        public void operation_excep(ExceptionHolder excep_holder)

--- a/test/regression/src/test/java/org/jacorb/test/bugs/bugrtj634/TimingServerImpl.java
+++ b/test/regression/src/test/java/org/jacorb/test/bugs/bugrtj634/TimingServerImpl.java
@@ -1,7 +1,9 @@
 package org.jacorb.test.bugs.bugrtj634;
 
+import org.jacorb.test.AnyException;
 import org.jacorb.test.ComplexTimingServerPOA;
 import org.jacorb.test.EmptyException;
+import org.omg.CORBA.Any;
 import org.omg.CORBA.NO_IMPLEMENT;
 import org.omg.CORBA.Object;
 
@@ -26,6 +28,11 @@ public class TimingServerImpl extends ComplexTimingServerPOA
    }
 
    public char ex_op(char ch, int delay) throws EmptyException
+   {
+      throw new NO_IMPLEMENT();
+   }
+
+   public void any_ex_op(String reason, Any anything, int delay) throws AnyException
    {
       throw new NO_IMPLEMENT();
    }

--- a/test/regression/src/test/java/org/jacorb/test/orb/ExceptionServerImpl.java
+++ b/test/regression/src/test/java/org/jacorb/test/orb/ExceptionServerImpl.java
@@ -1,8 +1,10 @@
 package org.jacorb.test.orb;
 
+import org.jacorb.test.AnyException;
 import org.jacorb.test.ExceptionServerPOA;
 import org.jacorb.test.MyUserException;
 import org.jacorb.test.NonEmptyException;
+import org.omg.CORBA.Any;
 
 public class ExceptionServerImpl extends ExceptionServerPOA
 {
@@ -25,4 +27,10 @@ public class ExceptionServerImpl extends ExceptionServerPOA
     {
         throw new MyUserException(reason, message);
     }
+
+    public void throwAnyException(String reason, Any anything) throws AnyException
+    {
+        throw new AnyException(reason, anything);
+    }
+
 }

--- a/test/regression/src/test/java/org/jacorb/test/orb/ExceptionTest.java
+++ b/test/regression/src/test/java/org/jacorb/test/orb/ExceptionTest.java
@@ -2,6 +2,7 @@ package org.jacorb.test.orb;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import org.jacorb.test.AnyException;
 import org.jacorb.test.ExceptionServer;
 import org.jacorb.test.ExceptionServerHelper;
 import org.jacorb.test.MyUserException;
@@ -13,6 +14,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.omg.CORBA.Any;
 
 /**
  * This class gathers all sorts of exception-related tests.
@@ -109,4 +111,23 @@ public class ExceptionTest extends ClientServerTestCase
             assertEquals("sample message", e.message);
         }
     }
+
+    @Test
+    public void testExceptionWithAny()
+    {
+        try
+        {
+            Any any = setup.getClientOrb().create_any();
+            any.insert_long(73);
+            server.throwAnyException("sample reason", any);
+            fail("Expected an exception to be thrown");
+        }
+        catch(AnyException e)
+        {
+            // expected
+            assertEquals("sample reason", e.getMessage());
+            assertEquals(73, e.anything.extract_long());
+        }
+    }
+
 }

--- a/test/regression/src/test/java/org/jacorb/test/orb/policies/ComplexTimingServerImpl.java
+++ b/test/regression/src/test/java/org/jacorb/test/orb/policies/ComplexTimingServerImpl.java
@@ -1,7 +1,9 @@
 package org.jacorb.test.orb.policies;
 
+import org.jacorb.test.AnyException;
 import org.jacorb.test.ComplexTimingServerPOA;
 import org.jacorb.test.EmptyException;
+import org.omg.CORBA.Any;
 
 public class ComplexTimingServerImpl extends ComplexTimingServerPOA
 {
@@ -41,6 +43,12 @@ public class ComplexTimingServerImpl extends ComplexTimingServerPOA
         {
             return ch;
         }
+    }
+
+    public void any_ex_op(String reason, Any anything, int delay) throws AnyException
+    {
+        sleep(delay);
+        throw new AnyException(reason, anything);
     }
 
     public long server_time(int delay)

--- a/test/regression/src/test/java/org/jacorb/test/orb/policies/TimingServerImpl.java
+++ b/test/regression/src/test/java/org/jacorb/test/orb/policies/TimingServerImpl.java
@@ -1,7 +1,9 @@
 package org.jacorb.test.orb.policies;
 
+import org.jacorb.test.AnyException;
 import org.jacorb.test.EmptyException;
 import org.jacorb.test.TimingServerPOA;
+import org.omg.CORBA.Any;
 
 public class TimingServerImpl extends TimingServerPOA
 {
@@ -26,6 +28,12 @@ public class TimingServerImpl extends TimingServerPOA
         {
             return ch;
         }
+    }
+
+    public void any_ex_op(String reason, Any anything, int delay) throws AnyException
+    {
+        sleep(delay);
+        throw new AnyException(reason, anything);
     }
 
     public long server_time(int delay)

--- a/test/regression/src/test/java/org/jacorb/test/orb/policies/TimingTest.java
+++ b/test/regression/src/test/java/org/jacorb/test/orb/policies/TimingTest.java
@@ -54,9 +54,19 @@ public class TimingTest extends CallbackTestCase
             wrong_exception ("ex_op_excep", excep_holder);
         }
 
+        public void any_ex_op_excep(ExceptionHolder excep_holder)
+        {
+            wrong_exception ("any_ex_op_excep", excep_holder);
+        }
+
         public void ex_op(char ami_return_val)
         {
             wrong_reply ("ex_op");
+        }
+
+        public void any_ex_op()
+        {
+            wrong_reply ("any_ex_op");
         }
 
         public void operation_excep(ExceptionHolder excep_holder)


### PR DESCRIPTION
During an unmarshal of a UserException with an Any type we ran into a
marshal exception.
It looks like the root cause is during the insert in
handle_receive_exception, we do a reflection call which calls ends up
calling \<MyUserException\>Helper.read on the stream.
If the \<MyUserException\> contains corba.any types, we need to check
the typecode which in DelegatingTypeCodeReader.readTypeCode we add a
mark to the input stream. When we later call a reset in
handle_receive_exception, it resets to the typecode instead of the start
of the exception.  Finally in the idl generated
\<ServerType\>Stub.remoteMethod, in the catch block for the
ApplicationException, we call \<MyUserException\>Helper.read on the input
steam.  Because the stream is not at the start of the exception we get a
marshal error when the \<MyUserException\> id doesn't match the data in the input stream.
This change saves the position of the start of the exception in
handle_receive_exception so we return to the start of the exception
instead of the last mark in the input stream.