### PR TITLE
Could multiprof:multiprof:1.0 drop off redundant dependencies?

### DIFF
--- a/test/interop/multiprof/pom.xml
+++ b/test/interop/multiprof/pom.xml
@@ -38,10 +38,12 @@
             <groupId>org.jacorb</groupId>
             <artifactId>jacorb</artifactId>
             <version>${version.jacorb}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jacorb</groupId>
-            <artifactId>jacorb-omgapi</artifactId>
+	    <exclusions>
+                <exclusion>
+                    <groupId>org.jacorb</groupId>
+                    <artifactId>jacorb-omgapi</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>antlr</groupId>
@@ -54,6 +56,20 @@
         <dependency>
 	    <groupId>nanocontainer</groupId>
 	    <artifactId>nanocontainer-remoting</artifactId>
+	    <exclusions>
+                <exclusion>
+                    <groupId>jmock</groupId>
+                    <artifactId>jmock-cglib</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>geronimo-spec</groupId>
+                    <artifactId>geronimo-spec-ejb</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>mx4j</groupId>
+                    <artifactId>mx4j-jmx</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
 	    <groupId>org.beanshell</groupId>
@@ -71,6 +87,12 @@
         <dependency>
             <groupId>picocontainer</groupId>
             <artifactId>picocontainer</artifactId>
+	    <exclusions>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
 	    <groupId>tanukisoft</groupId>


### PR DESCRIPTION
Hi! I found the pom file of project **_multiprof:multiprof:1.0_** introduced **_21_** dependencies. However, among them, **_5_** libraries (**_23%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
geronimo-spec:geronimo-spec-ejb:jar:2.1-rc2:compile
jmock:jmock-cglib:jar:1.0.1:compile
xml-apis:xml-apis:jar:1.0.b2:compile
mx4j:mx4j-jmx:jar:2.1.1:compile
org.jacorb:jacorb-omgapi:jar:3.6:compile
## Outdated dependencies
jmock:jmock-cglib:1.0.1 (**_6458_** days without maintenance)
xml-apis:xml-apis:1.0.b2 (**_6458_** days without maintenance)

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, one of the redundant dependencies **_org.jacorb:jacorb-omgapi:jar:3.6:compile_** induced dependency conflict in the dependency graph. As such, I suggest a refactoring operation for **_multiprof:multiprof:1.0_**’s pom file.

The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_multiprof:multiprof:1.0_**’s maven tests.

Best regards
![image](https://user-images.githubusercontent.com/78527112/160540080-b2833910-937b-4d40-b89f-0cfffacbab73.png)
