### PR TITLE
replace incompatible Thread.destroy call by Thread.stop

### DIFF
--- a/demo/dds/src/main/java/org/jacorb/demo/dds/dcps/Server.java
+++ b/demo/dds/src/main/java/org/jacorb/demo/dds/dcps/Server.java
@@ -89,7 +89,7 @@ public class Server implements Runnable {
     }
 
     public void end() {
-        Thread.currentThread().destroy();
+        Thread.currentThread().stop();
     }
 
     /**

--- a/demo/dds/src/main/java/org/jacorb/demo/dds/dcps/foosample/FooConsumer.java
+++ b/demo/dds/src/main/java/org/jacorb/demo/dds/dcps/foosample/FooConsumer.java
@@ -201,7 +201,7 @@ public class FooConsumer implements Runnable {
 
 
     public void end(){
-        Thread.currentThread().destroy();
+        Thread.currentThread().stop();
     }
 
     /**

--- a/demo/dds/src/main/java/org/jacorb/demo/dds/dcps/foosample/FooProducer.java
+++ b/demo/dds/src/main/java/org/jacorb/demo/dds/dcps/foosample/FooProducer.java
@@ -74,7 +74,7 @@ public class FooProducer implements Runnable {
     }
 
     public void end() {
-        Thread.currentThread().destroy();
+        Thread.currentThread().stop();
     }
 
     /**


### PR DESCRIPTION
Thread.destroy has been removed in more recent JDK making it impossible to run this regression test with such JDK