### PR TITLE
fix toolsjar dependency

### DIFF
--- a/demo/dds/src/main/java/org/jacorb/demo/dds/dcps/Server.java
+++ b/demo/dds/src/main/java/org/jacorb/demo/dds/dcps/Server.java
@@ -89,7 +89,7 @@ public class Server implements Runnable {
     }
 
     public void end() {
-        Thread.currentThread().destroy();
+        Thread.currentThread().stop();
     }
 
     /**

--- a/demo/dds/src/main/java/org/jacorb/demo/dds/dcps/foosample/FooConsumer.java
+++ b/demo/dds/src/main/java/org/jacorb/demo/dds/dcps/foosample/FooConsumer.java
@@ -201,7 +201,7 @@ public class FooConsumer implements Runnable {
 
 
     public void end(){
-        Thread.currentThread().destroy();
+        Thread.currentThread().stop();
     }
 
     /**

--- a/demo/dds/src/main/java/org/jacorb/demo/dds/dcps/foosample/FooProducer.java
+++ b/demo/dds/src/main/java/org/jacorb/demo/dds/dcps/foosample/FooProducer.java
@@ -74,7 +74,7 @@ public class FooProducer implements Runnable {
     }
 
     public void end() {
-        Thread.currentThread().destroy();
+        Thread.currentThread().stop();
     }
 
     /**

--- a/test/regression/pom.xml
+++ b/test/regression/pom.xml
@@ -127,14 +127,6 @@
             <version>${byteman.version}</version>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>com.sun</groupId>
-            <artifactId>tools</artifactId>
-            <version>1.6.0</version>
-            <scope>system</scope>
-            <systemPath>${toolsjar}</systemPath>
-        </dependency>
         <dependency>
         	<groupId>org.mockito</groupId>
         	<artifactId>mockito-all</artifactId>
@@ -680,6 +672,25 @@
     </build>
 
     <profiles>
+
+		<profile>
+			<id>default-toolsjar</id>
+            <activation>
+                <file>
+                    <exists>${toolsjar}</exists>
+                </file>
+            </activation>
+			<dependencies>
+		        <dependency>
+		            <groupId>com.sun</groupId>
+		            <artifactId>tools</artifactId>
+		            <version>1.6.0</version>
+		            <scope>system</scope>
+		            <systemPath>${toolsjar}</systemPath>
+		        </dependency>
+			</dependencies>
+		</profile>
+		
         <profile>
             <id>default-test</id>
             <activation>
@@ -777,5 +788,6 @@
                 </plugins>
             </build>
         </profile>
+		
     </profiles>
 </project>


### PR DESCRIPTION
Make tools.jar dependency (better) profiled to enable building&running tests with JDK9+