### PR TITLE
replace retired SSLSession.getPeerCertificateChain method

### DIFF
--- a/core/src/main/java/org/jacorb/security/ssl/sun_jsse/ServerInvocationInterceptor.java
+++ b/core/src/main/java/org/jacorb/security/ssl/sun_jsse/ServerInvocationInterceptor.java
@@ -156,8 +156,8 @@ public class ServerInvocationInterceptor
 
         try
         {
-            javax.security.cert.X509Certificate[] certs =
-                sslSocket.getSession().getPeerCertificateChain();
+            java.security.cert.Certificate[] certs =
+                    sslSocket.getSession().getPeerCertificates();
 
             int size = certs.length;
             java.security.cert.X509Certificate[] newCerts =


### PR DESCRIPTION
JDK15 retired the (long since) deprecated SSLSession.getPeerCertificateChain method which since then throws an UnsupportedOperationException.
Replacing this with the equivalent (and portable) SSLSession.getPeerCertificateChain method fixes this.