### PR TITLE
Use the correct property name

### DIFF
--- a/core/src/main/java/org/jacorb/security/ssl/sun_jsse/SSLSocketFactory.java
+++ b/core/src/main/java/org/jacorb/security/ssl/sun_jsse/SSLSocketFactory.java
@@ -158,7 +158,7 @@ public class SSLSocketFactory
         if (configuration.getAttribute("jacorb.security.ssl.client.protocols", null) != null)
         {
             enabledProtocols = 
-                configuration.getAttributeAsStringsArray ("jacorb.security.ssl.server.protocols");
+                configuration.getAttributeAsStringsArray ("jacorb.security.ssl.client.protocols");
 
             if (logger.isDebugEnabled())
             {


### PR DESCRIPTION
Looks like a copy and paste issue. The implementaion checks if the property "jacorb.security.ssl.client.protocols" is present and if so it gets "jacorb.security.ssl.server.protocols" which is obviously the wrong value.