### PR TITLE
Use numeric constants because org.omg.CORBA is not available with Java…

### DIFF
--- a/idl-compiler/src/main/java/org/jacorb/idl/AnyType.java
+++ b/idl-compiler/src/main/java/org/jacorb/idl/AnyType.java
@@ -71,7 +71,7 @@ public class AnyType
 
     public int getTCKind()
     {
-        return 11;
+        return 11; // org.omg.CORBA.TCKind._tk_any
     }
 
     public String printReadExpression( String strname )

--- a/idl-compiler/src/main/java/org/jacorb/idl/ArrayTypeSpec.java
+++ b/idl-compiler/src/main/java/org/jacorb/idl/ArrayTypeSpec.java
@@ -224,7 +224,7 @@ public class ArrayTypeSpec
 
     public int getTCKind()
     {
-        return 20;
+        return 20; // org.omg.CORBA.TCKind._tk_array
     }
 
     public String helperName()

--- a/idl-compiler/src/main/java/org/jacorb/idl/ArrayTypeSpec.java
+++ b/idl-compiler/src/main/java/org/jacorb/idl/ArrayTypeSpec.java
@@ -224,7 +224,7 @@ public class ArrayTypeSpec
 
     public int getTCKind()
     {
-    	return org.omg.CORBA.TCKind._tk_array;
+        return 20;
     }
 
     public String helperName()

--- a/idl-compiler/src/main/java/org/jacorb/idl/BooleanType.java
+++ b/idl-compiler/src/main/java/org/jacorb/idl/BooleanType.java
@@ -52,7 +52,7 @@ public class BooleanType
 
     public int getTCKind()
     {
-        return 8;
+        return 8; // org.omg.CORBA.TCKind._tk_boolean
     }
 
     public String toString()

--- a/idl-compiler/src/main/java/org/jacorb/idl/CharType.java
+++ b/idl-compiler/src/main/java/org/jacorb/idl/CharType.java
@@ -81,9 +81,9 @@ public class CharType
     {
         if( wide )
         {
-            return 26;
+            return 26; // org.omg.CORBA.TCKind._tk_wchar
         }
-        return 9;
+        return 9; // org.omg.CORBA.TCKind._tk_char
     }
 
     public String holderName()

--- a/idl-compiler/src/main/java/org/jacorb/idl/DoubleType.java
+++ b/idl-compiler/src/main/java/org/jacorb/idl/DoubleType.java
@@ -57,7 +57,7 @@ public class DoubleType
 
     public int getTCKind()
     {
-        return 7;
+        return 7; // org.omg.CORBA.TCKind._tk_double
     }
 
     public String toString()

--- a/idl-compiler/src/main/java/org/jacorb/idl/FixedPointConstType.java
+++ b/idl-compiler/src/main/java/org/jacorb/idl/FixedPointConstType.java
@@ -59,7 +59,7 @@ public class FixedPointConstType
 
     public int getTCKind()
     {
-        return 28;
+        return 28; // org.omg.CORBA.TCKind._tk_fixed
     }
 
     public void parse()

--- a/idl-compiler/src/main/java/org/jacorb/idl/FixedPointType.java
+++ b/idl-compiler/src/main/java/org/jacorb/idl/FixedPointType.java
@@ -79,7 +79,7 @@ public class FixedPointType
 
     public int getTCKind()
     {
-        return 28;
+        return 28; // org.omg.CORBA.TCKind._tk_fixed
     }
 
 

--- a/idl-compiler/src/main/java/org/jacorb/idl/FixedPointType.java
+++ b/idl-compiler/src/main/java/org/jacorb/idl/FixedPointType.java
@@ -79,7 +79,7 @@ public class FixedPointType
 
     public int getTCKind()
     {
-        return org.omg.CORBA.TCKind._tk_fixed;
+        return 28;
     }
 
 

--- a/idl-compiler/src/main/java/org/jacorb/idl/FloatType.java
+++ b/idl-compiler/src/main/java/org/jacorb/idl/FloatType.java
@@ -51,7 +51,7 @@ public class FloatType
 
     public int getTCKind()
     {
-        return 6;
+        return 6; // org.omg.CORBA.TCKind._tk_float
     }
 
     public String toString()

--- a/idl-compiler/src/main/java/org/jacorb/idl/LongLongType.java
+++ b/idl-compiler/src/main/java/org/jacorb/idl/LongLongType.java
@@ -60,9 +60,9 @@ public class LongLongType
     {
         if( unsigned )
         {
-            return 24; // tk_ulonglong
+            return 24; // // org.omg.CORBA.TCKind._tk_ulonglong
         }
-        return 23; // tk_longlong
+        return 23; // // org.omg.CORBA.TCKind._tk_longlong
     }
 
     public String toString()

--- a/idl-compiler/src/main/java/org/jacorb/idl/LongType.java
+++ b/idl-compiler/src/main/java/org/jacorb/idl/LongType.java
@@ -56,7 +56,7 @@ public class LongType
 
     public int getTCKind()
     {
-        return ( ( unsigned ) ? 5 : 3 );
+        return ( ( unsigned ) ? 5 : 3 ); // org.omg.CORBA.TCKind._tk_ulong : // org.omg.CORBA.TCKind._tk_long
     }
 
     public String toString()

--- a/idl-compiler/src/main/java/org/jacorb/idl/LongType.java
+++ b/idl-compiler/src/main/java/org/jacorb/idl/LongType.java
@@ -56,7 +56,7 @@ public class LongType
 
     public int getTCKind()
     {
-        return ( ( unsigned ) ? 5 : 3 ); // org.omg.CORBA.TCKind._tk_ulong : // org.omg.CORBA.TCKind._tk_long
+        return ( ( unsigned ) ? 5 : 3 ); // org.omg.CORBA.TCKind._tk_ulong : org.omg.CORBA.TCKind._tk_long
     }
 
     public String toString()

--- a/idl-compiler/src/main/java/org/jacorb/idl/OctetType.java
+++ b/idl-compiler/src/main/java/org/jacorb/idl/OctetType.java
@@ -61,7 +61,7 @@ public class OctetType
 
     public int getTCKind()
     {
-        return 10;
+        return 10; // org.omg.CORBA.TCKind._tk_octet
     }
 
     public void parse()

--- a/idl-compiler/src/main/java/org/jacorb/idl/ShortType.java
+++ b/idl-compiler/src/main/java/org/jacorb/idl/ShortType.java
@@ -53,9 +53,9 @@ public class ShortType
     {
         if( unsigned )
         {
-            return 4; //_tk_ushort
+            return 4; // org.omg.CORBA.TCKind._tk_ushort
         }
-        return 2; // _tk_short
+        return 2; // // org.omg.CORBA.TCKind._tk_short
     }
 
     public String toString()

--- a/idl-compiler/src/main/java/org/jacorb/idl/StringType.java
+++ b/idl-compiler/src/main/java/org/jacorb/idl/StringType.java
@@ -74,7 +74,7 @@ public class StringType
 
     public int getTCKind()
     {
-    	return org.omg.CORBA.TCKind._tk_string;
+        return 18;
     }
 
     public void setEnclosingSymbol( IdlSymbol s )

--- a/idl-compiler/src/main/java/org/jacorb/idl/StringType.java
+++ b/idl-compiler/src/main/java/org/jacorb/idl/StringType.java
@@ -74,7 +74,7 @@ public class StringType
 
     public int getTCKind()
     {
-        return 18;
+        return 18; // org.omg.CORBA.TCKind._tk_string
     }
 
     public void setEnclosingSymbol( IdlSymbol s )

--- a/idl-compiler/src/main/java/org/jacorb/idl/StructType.java
+++ b/idl-compiler/src/main/java/org/jacorb/idl/StructType.java
@@ -143,7 +143,7 @@ public class StructType
 
     public int getTCKind()
     {
-    	return org.omg.CORBA.TCKind._tk_struct;
+        return 15;
     }
 
     public boolean basic()

--- a/idl-compiler/src/main/java/org/jacorb/idl/StructType.java
+++ b/idl-compiler/src/main/java/org/jacorb/idl/StructType.java
@@ -143,7 +143,7 @@ public class StructType
 
     public int getTCKind()
     {
-        return 15;
+        return 15; // // org.omg.CORBA.TCKind._tk_struct
     }
 
     public boolean basic()

--- a/idl-compiler/src/main/java/org/jacorb/idl/ValueDecl.java
+++ b/idl-compiler/src/main/java/org/jacorb/idl/ValueDecl.java
@@ -411,8 +411,8 @@ public class ValueDecl
                 // type modifier
                 "(short)" +
                 (this.isCustomMarshalled()
-                        ? org.omg.CORBA.VM_CUSTOM.value
-                        : org.omg.CORBA.VM_NONE.value
+                        ? 1
+                        : 0
                 ) + ", " +
                 // concrete base type
                 baseType + ", " +
@@ -444,8 +444,8 @@ public class ValueDecl
 
         String memberTypeExpression = typeSpec.getTypeCodeExpression(knownTypes);
         short access = m.isPublic
-            ? org.omg.CORBA.PUBLIC_MEMBER.value
-            : org.omg.CORBA.PRIVATE_MEMBER.value;
+            ? (short)1
+            : (short)0;
 
         return "new org.omg.CORBA.ValueMember (" +
             "\"" + m.name + "\", \"" + typeSpec.id() +

--- a/idl-compiler/src/main/java/org/jacorb/idl/ValueDecl.java
+++ b/idl-compiler/src/main/java/org/jacorb/idl/ValueDecl.java
@@ -411,8 +411,8 @@ public class ValueDecl
                 // type modifier
                 "(short)" +
                 (this.isCustomMarshalled()
-                        ? 1
-                        : 0
+                        ? 1 // org.omg.CORBA.VM_CUSTOM
+                        : 0 // org.omg.CORBA.VM_NONE
                 ) + ", " +
                 // concrete base type
                 baseType + ", " +
@@ -444,8 +444,8 @@ public class ValueDecl
 
         String memberTypeExpression = typeSpec.getTypeCodeExpression(knownTypes);
         short access = m.isPublic
-            ? (short)1
-            : (short)0;
+            ? (short)1 // org.omg.CORBA.PUBLIC_MEMBER
+            : (short)0; // org.omg.CORBA.PRIVATE_MEMBER
 
         return "new org.omg.CORBA.ValueMember (" +
             "\"" + m.name + "\", \"" + typeSpec.id() +

--- a/idl-compiler/src/main/java/org/jacorb/idl/VectorType.java
+++ b/idl-compiler/src/main/java/org/jacorb/idl/VectorType.java
@@ -196,7 +196,7 @@ public abstract class VectorType
 
     public int getTCKind()
     {
-        return 20;
+        return 20; // org.omg.CORBA.TCKind._tk_array
     }
 
 }

--- a/idl-compiler/src/main/java/org/jacorb/idl/VectorType.java
+++ b/idl-compiler/src/main/java/org/jacorb/idl/VectorType.java
@@ -193,10 +193,10 @@ public abstract class VectorType
     {
         visitor.visitVectorType(this);
     }
-    
+
     public int getTCKind()
     {
-    	return org.omg.CORBA.TCKind._tk_array;
+        return 20;
     }
 
 }

--- a/idl-compiler/src/main/java/org/jacorb/idl/VoidTypeSpec.java
+++ b/idl-compiler/src/main/java/org/jacorb/idl/VoidTypeSpec.java
@@ -41,15 +41,15 @@ public class VoidTypeSpec
 
     public int getTCKind()
     {
-    	return org.omg.CORBA.TCKind._tk_void;
+    	return 1;
     }
-    
+
     /**
      * @return true if this is a basic type
      */
 
     public boolean basic()
-    {        
+    {
         return true;
     }
 

--- a/idl-compiler/src/main/java/org/jacorb/idl/VoidTypeSpec.java
+++ b/idl-compiler/src/main/java/org/jacorb/idl/VoidTypeSpec.java
@@ -41,7 +41,7 @@ public class VoidTypeSpec
 
     public int getTCKind()
     {
-    	return 1;
+        return 1; // org.omg.CORBA.TCKind._tk_void
     }
 
     /**


### PR DESCRIPTION
… 17 and newer, makes it possible to compile the jacorb IDL compiler natively with JDK 17 and newer

    * idl-compiler/src/main/java/org/jacorb/idl/ArrayTypeSpec.java:
    * idl-compiler/src/main/java/org/jacorb/idl/FixedPointType.java:
    * idl-compiler/src/main/java/org/jacorb/idl/StringType.java:
    * idl-compiler/src/main/java/org/jacorb/idl/StructType.java:
    * idl-compiler/src/main/java/org/jacorb/idl/ValueDecl.java:
    * idl-compiler/src/main/java/org/jacorb/idl/VectorType.java:
    * idl-compiler/src/main/java/org/jacorb/idl/VoidTypeSpec.java: