### PR TITLE
Allow pull requests CI to run also targeting own fork

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   build:
     # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idif
-    if: github.repository == 'JacORB/JacORB' && github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Changed maven.yml to let the CI test also run when it is a pull request to an own fork, makes it possible to test CI changes before targeting the JacORB/JacORB repo