### PR TITLE
Use -fae (fail at end) to run the full build/tests even when somethin…

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -38,7 +38,7 @@ jobs:
       with:
         maven-version: 3.6.3
     - name: Build with Maven
-      run: mvn -B -V -DskipPDFGeneration clean install
+      run: mvn -fae -B -V -DskipPDFGeneration clean install
 #    - name: Setup tmate session
 #      uses: mxschmitt/action-tmate@v3
 #      if: ${{ failure() }}


### PR DESCRIPTION
…g changes, now see the CI to stop when just one test fails because of jitter

    * .github/workflows/maven.yml: